### PR TITLE
Add accept policy verification on user creation

### DIFF
--- a/src/zoauthServer.js
+++ b/src/zoauthServer.js
@@ -348,6 +348,7 @@ export class ZOAuthServer {
     const policies = app.policies || { userNeedEmail: true }; // TODO remove this default policies
     const validationPolicy = policies.validation || "none";
     const validation = !!(validationPolicy === "none");
+
     if (
       StringTools.stringIsEmpty(username) ||
       (policies.userNeedEmail && StringTools.stringIsEmpty(email)) ||
@@ -373,6 +374,10 @@ export class ZOAuthServer {
     } else if (
       ZOAuthServer.validateCredentialsValue(username, email, password, policies)
     ) {
+      if (!extras.accept) {
+        response.result = { error: "Please accept policies's terms" };
+        return response;
+      }
       user = await this.model.getUser(null, username, email);
       if (!user) {
         user = {

--- a/tests/zoauthRouter.test.js
+++ b/tests/zoauthRouter.test.js
@@ -59,6 +59,7 @@ describeParams(
           username: "toto",
           password: "12345",
           email: "toto@test.com",
+          accept: true,
         };
         response = await authServer.registerUser(params);
         ({ result } = response);
@@ -153,6 +154,7 @@ describeParams(
           username: "toto",
           password: "12345",
           email: "toto@test.com",
+          accept: true,
         };
         response = await authServer.registerUser(params);
         ({ result } = response);

--- a/tests/zoauthServer.test.js
+++ b/tests/zoauthServer.test.js
@@ -170,6 +170,18 @@ describeParams(
         response = await authServer.registerUser(params);
         ({ result } = response);
         expect(result.error).toEqual("Please accept policies's terms");
+
+        params = {
+          client_id: clientId,
+          username: "toto",
+          password: "12345",
+          email: "toto@test.com",
+          accept: false,
+        };
+        await authServer.registerUser(params);
+        response = await authServer.registerUser(params);
+        ({ result } = response);
+        expect(result.error).toEqual("Please accept policies's terms");
       });
     });
 

--- a/tests/zoauthServer.test.js
+++ b/tests/zoauthServer.test.js
@@ -98,6 +98,7 @@ describeParams(
           username: "toto",
           password: "12345",
           email: "toto@test.com",
+          accept: true,
         };
         response = await authServer.registerUser(params);
         ({ result } = response);
@@ -127,12 +128,12 @@ describeParams(
         const clientId = result.client_id;
         expect(clientId).toHaveLength(64);
 
-        params = { client_id: clientId };
+        params = { client_id: clientId, accept: true };
         response = await authServer.registerUser(params);
         ({ result } = response);
         expect(result.error).toEqual("Wrong parameters sent");
 
-        params = { client_id: clientId, email: "tutu@test.com" };
+        params = { client_id: clientId, email: "tutu@test.com", accept: true };
         response = await authServer.registerUser(params);
         ({ result } = response);
         expect(result.error).toEqual("Wrong parameters sent");
@@ -141,6 +142,7 @@ describeParams(
           client_id: clientId,
           email: "tutu@test.com",
           username: "tutu",
+          accept: true,
         };
         response = await authServer.registerUser(params);
         ({ result } = response);
@@ -151,11 +153,23 @@ describeParams(
           username: "toto",
           password: "12345",
           email: "toto@test.com",
+          accept: true,
         };
         await authServer.registerUser(params);
         response = await authServer.registerUser(params);
         ({ result } = response);
         expect(result.error).toEqual("Not valid user: toto");
+
+        params = {
+          client_id: clientId,
+          username: "toto",
+          password: "12345",
+          email: "toto@test.com",
+        };
+        await authServer.registerUser(params);
+        response = await authServer.registerUser(params);
+        ({ result } = response);
+        expect(result.error).toEqual("Please accept policies's terms");
       });
     });
 
@@ -306,6 +320,7 @@ describeParams(
           username: "toto",
           password: "12345",
           email: "toto@test.com",
+          accept: true,
         };
         response = await authServer.registerUser(params);
         ({ result } = response);
@@ -355,6 +370,7 @@ describeParams(
           username: "toto",
           password: "12345",
           email: "toto@test.com",
+          accept: true,
         };
         response = await authServer.registerUser(params);
         ({ result } = response);
@@ -410,6 +426,7 @@ describeParams(
           username: "toto",
           password: "12345",
           email: "toto@test.com",
+          accept: true,
         };
         response = await authServer.registerUser(params);
         ({ result } = response);
@@ -471,6 +488,7 @@ describeParams(
           username: "toto",
           password: "12345",
           email: "toto@test.com",
+          accept: true,
         };
         response = await authServer.registerUser(params);
         ({ result } = response);


### PR DESCRIPTION
# Description

Add accept agreement policy verification on create user.

Refer to Zoapp/front#93 

## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
:warning: make sure you pass `accept` as a parameter to `registerUser` service.

# How Has This Been Tested?

Add test for get error message related to no accept policies's terms. `Please accept policies's terms `

**Test Configuration**:
* Yarn/npm/nodejs version:1.12.3/6.4.1/8.14.1

# Checklist:

Please remove lines that are not relevant

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works