### PR TITLE
Update setUser function to be able to update by userId

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint src tests",
     "start": "node dist",
     "start:dev": "nodemon -w src --exec \"babel-node src\"",
-    "test": "jest --runInBand --forceExit",
+    "test": "jest --runInBand --detectOpenHandles --forceExit",
     "willPublish": "yarn run lint:prod && yarn run test && yarn run build:prod"
   },
   "keywords": [

--- a/src/model/index.js
+++ b/src/model/index.js
@@ -146,10 +146,14 @@ export class ZOAuthModel {
 
   async setUser(user, users = this.getUsers()) {
     const u = { ...user };
-    const { username, email } = user;
+    const { id, username, email } = user;
     // const password = user.password;
-
-    let cachedUser = await this.getUser(username, email, users);
+    let cachedUser = null;
+    if (username && email && !id) {
+      cachedUser = await this.getUser(null, username, email, users);
+    } else {
+      cachedUser = await this.getUser(id, null, null, users);
+    }
     let userId = null;
     if (!user.id) {
       // generate user_id
@@ -163,6 +167,7 @@ export class ZOAuthModel {
     } else if (cachedUser) {
       userId = user.id;
     } else {
+      // Then user.id is already defined.
       throw new Error("unknown user");
     }
     Object.keys(u).forEach((key) => {

--- a/tests/model/index.test.js
+++ b/tests/model/index.test.js
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2015-present, CWB SAS
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { ZOAuthModel } from "../../src/model";
+
+describe("zoauth - model", () => {
+  const zoAuthModel = new ZOAuthModel({}, null);
+  zoAuthModel.generateId = () => "abcd";
+
+  const getItemSpy = (preexistingUser) =>
+    jest.fn((arg) => {
+      if (arg === preexistingUser.id) return Promise.resolve(preexistingUser);
+      return Promise.resolve(null);
+    });
+
+  const setItemSpy = (updatedUser) =>
+    jest.fn().mockResolvedValue(Promise.resolve(updatedUser));
+
+  const UsersModelMock = (existingUser, updatedUser) => ({
+    getItem: getItemSpy(existingUser),
+    setItem: setItemSpy(updatedUser),
+    nextItem: getItemSpy(existingUser),
+  });
+
+  describe("setUser", () => {
+    it("should set a user by id", async () => {
+      const id = "abcd";
+
+      const updatedUser = {
+        id,
+        username: "final",
+        email: "final@example.fr",
+      };
+
+      const preexistingUser = {
+        id,
+        username: "initial",
+        email: "initial@example.fr",
+      };
+      const res = await zoAuthModel.setUser(
+        updatedUser,
+        UsersModelMock(preexistingUser, updatedUser),
+      );
+      expect(res).toMatchObject(updatedUser);
+      expect(res.salt).toBeUndefined();
+      expect(res.password).toBeUndefined(); // Password shouldn't be returned
+    });
+    it("should set a user passwd by username/email", async () => {
+      const updatedUser = {
+        username: "final",
+        email: "final@example.fr",
+        password: "passwordUpdate",
+      };
+
+      const preexistingUser = {
+        username: "final",
+        email: "final@example.fr",
+      };
+
+      const res = await zoAuthModel.setUser(
+        updatedUser,
+        UsersModelMock(preexistingUser, updatedUser),
+      );
+      expect(res).toMatchObject(preexistingUser); // Check for pre-existing user, since username/email will not change
+      expect(res.salt).toBeDefined();
+      expect(res.password).toBeUndefined(); // Password shouldn't be returned
+    });
+    it("should throw an error if user id doesn't exist", async () => {
+      const updatedUser = {
+        id: "abcd",
+        username: "final",
+        email: "final@example.fr",
+      };
+
+      const preexistingUser = {
+        id: "dcba",
+        username: "initial",
+        email: "initial@example.fr",
+      };
+
+      try {
+        await zoAuthModel.setUser(
+          updatedUser,
+          UsersModelMock(preexistingUser, updatedUser),
+        );
+      } catch (err) {
+        expect(err.message).toEqual("unknown user");
+      }
+    });
+    it("should update password (salt regeneration)", async () => {
+      const id = "abcd";
+
+      const updatedUser = {
+        id,
+        username: "final",
+        email: "final@example.fr",
+        password: "1",
+      };
+
+      const preexistingUser = {
+        id,
+        username: "initial",
+        email: "initial@example.fr",
+      };
+
+      const res = await zoAuthModel.setUser(
+        updatedUser,
+        UsersModelMock(preexistingUser, updatedUser),
+      );
+      expect(res.salt).toBeDefined();
+      expect(res.password).toBeUndefined(); // Password shouldn't be returned
+    });
+  });
+});


### PR DESCRIPTION
# Description

Simple update to be able to setUser by username/name or userId

## Type of change

- [x] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

Added a few test cases on `model/index` on setUser. I will add more tests for `model/index.js` in the future

**Test Configuration**:
* Yarn/npm/nodejs version: v1.12.1/v5.6.0/v8.10.0
* OS version: macOS 10.14.2
* Chrome version: Google Chrome 71.0.3578.98

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
