### PR TITLE
Fix missing validation on username/email when updating a user

### DIFF
--- a/src/model/index.js
+++ b/src/model/index.js
@@ -153,6 +153,26 @@ export class ZOAuthModel {
       cachedUser = await this.getUser(null, username, email, users);
     } else {
       cachedUser = await this.getUser(id, null, null, users);
+      const cachedValidationNameUser = await this.getUser(
+        null,
+        username,
+        null,
+        users,
+      );
+      const cachedValidationMailUser = await this.getUser(
+        null,
+        null,
+        email,
+        users,
+      );
+      if (
+        (cachedValidationNameUser &&
+          cachedValidationNameUser.id !== cachedUser.id) ||
+        (cachedValidationMailUser &&
+          cachedValidationMailUser.id !== cachedUser.id)
+      ) {
+        throw new Error("username / email are already used");
+      }
     }
     let userId = null;
     if (!user.id) {


### PR DESCRIPTION
# Description

Now checking for existing username/email when updating a user

## Type of change

- [x] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

Since it only edit `setUser`, tests that were done on the previous PR #39 

**Test Configuration**:
* Yarn/npm/nodejs version: v1.12.1/v5.6.0/v8.10.0
* OS version: macOS 10.14.2
* Chrome version: Google Chrome 71.0.3578.98

# Checklist:

Please remove lines that are not relevant

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code